### PR TITLE
Disable line number mapping.

### DIFF
--- a/cinje/block/module.py
+++ b/cinje/block/module.py
@@ -78,9 +78,9 @@ class Module(object):
 		
 		yield Line(0, '')
 		
-		if __debug__:
-			yield Line(0, '__mapping__ = [' + ','.join(str(i) for i in mapping) + ']')
+		#if __debug__:
+		#	yield Line(0, '__mapping__ = [' + ','.join(str(i) for i in mapping) + ']')
 		
-		yield Line(0, '__gzmapping__ = b"' + red(mapping).replace('"', '\"') + '"')
+		#yield Line(0, '__gzmapping__ = b"' + red(mapping).replace('"', '\"') + '"')
 		
 		context.flag.remove('init')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import sys
 import codecs
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 if sys.version_info < (2, 7):
@@ -59,7 +59,7 @@ setup(
 			"Topic :: Utilities",
 		],
 	
-	packages = ['cinje'],
+	packages = find_packages(),
 	include_package_data = True,
 	package_data = {'': ['README.rst', 'LICENSE.txt']},
 	namespace_packages = [],


### PR DESCRIPTION
> Care of [CEGID](https://www.cegid.com/global/), my current employer, there are a collection of downstream changes utilized by the [RITA](https://www.cegid.com/global/products/cegid-rita/) job offer multi-posting platform. This pull request aims to homogenize the changes, eliminate the need to pin specific branches instead of released versions, and generally improve the project.

The mere presence of the generated line number mappings causes certain Python versions and configurations to fail to import the template module, generating an inscrutable error about unterminated values. This change eliminates the problem, but reduces debug–ability by removing the "origin line" mapping from each template module.

Corrects #30.